### PR TITLE
fix: handle parition_tag contains slash

### DIFF
--- a/pymilvusdm/core/read_milvus_data.py
+++ b/pymilvusdm/core/read_milvus_data.py
@@ -1,5 +1,7 @@
-import numpy as np
 import os
+
+import numpy as np
+
 
 # read data from one collection(_defult) or one partition
 class ReadMilvusDB:
@@ -9,44 +11,43 @@ class ReadMilvusDB:
         self.mysql_p = mysql_p
 
     def read_del_file(self, collection_path, segment_id):
-        del_file = collection_path + '/' + segment_id + '/deleted_docs'
+        del_file = os.path.join(collection_path, segment_id, "deleted_docs")
         del_ids = np.fromfile(del_file, dtype=np.int32)
         return del_ids
 
     def read_uid_file(self, collection_path, segment_id):
-        uid_file = collection_path + '/' + segment_id + '/' + segment_id + '.uid'
+        uid_file = os.path.join(collection_path, segment_id, segment_id + ".uid")
         ids = np.fromfile(uid_file, dtype=np.int64)
         ids = ids[1:]
         return ids
 
     def read_rv_float_file(self, collection_path, segment_id, rows, dim):
-        rv_file = collection_path + '/' + segment_id + '/' + segment_id + '.rv'
+        rv_file = os.path.join(collection_path, segment_id, segment_id + ".rv")
         self.logger.debug("Reading float data in local file: {}".format(rv_file))
         vectors = np.fromfile(rv_file, dtype=np.float32)
         vectors = vectors[2:].reshape(rows, dim).tolist()
         return vectors
 
     def read_rv_binary_file(self, collection_path, segment_id, rows, dim):
-        rv_file = collection_path + '/' + segment_id + '/' + segment_id + '.rv'
+        rv_file = os.path.join(collection_path, segment_id, segment_id + ".rv")
         self.logger.debug("Reading binary data in local file: {}".format(rv_file))
         v = np.fromfile(rv_file, dtype=np.uint8)
-        vectors = [vector.tobytes() for vector in v[8:].reshape(rows, int(dim/8))]
+        vectors = [vector.tobytes() for vector in v[8:].reshape(rows, int(dim / 8))]
         return vectors
 
     def get_segment_data(self, collection_path, segment_id, dim, rows, types):
         del_ids = self.read_del_file(collection_path, segment_id)
         rows += len(del_ids[2:])
-        if types in [1,2]:
+        if types in [1, 2]:
             vectors = self.read_rv_float_file(collection_path, segment_id, rows, dim)
         else:
-            vectors = self.read_rv_binary_file(collection_path, segment_id, rows, dim)   
+            vectors = self.read_rv_binary_file(collection_path, segment_id, rows, dim)
         ids = self.read_uid_file(collection_path, segment_id)
         if len(del_ids[2:]) != 0:
             vectors = np.delete(vectors, del_ids[2:], axis=0).tolist()
             ids = np.delete(ids, del_ids[2:], axis=0)
-            self.logger.debug('The Segment: {} has deleted data, total num: {}.'.format(segment_id, len(del_ids[2:])))
+            self.logger.debug("The Segment: {} has deleted data, total num: {}.".format(segment_id, len(delids[2:])))
 
-        # print(len(vectors), ids)
         return vectors, ids
 
     def get_files_data(self, table_id, collection_path, milvus_meta):
@@ -65,8 +66,8 @@ class ReadMilvusDB:
 
     def get_partition_data(self, milvus_meta, collection_name, partition_tag):
         partition_name = milvus_meta.get_partition_name(collection_name, partition_tag)
-        collection_path = self.milvus_dir + '/db/tables/' + partition_name
-        total_vectors, total_ids, total_rows = self.get_files_data(partition_name, collection_path, milvus_meta)
+        partition_path = os.path.join(self.milvus_dir, "db", "tables", partition_name)
+        total_vectors, total_ids, total_rows = self.get_files_data(partition_name, partition_path, milvus_meta)
         return total_vectors, total_ids, total_rows
 
     def read_milvus_file(self, milvus_meta, collection_name, partition_tag):
@@ -75,7 +76,7 @@ class ReadMilvusDB:
         if partition_tag:
             total_vectors, total_ids, total_rows = self.get_partition_data(milvus_meta, collection_name, partition_tag)
         else:
-            collection_path = self.milvus_dir + '/db/tables/' + collection_name
+            collection_path = os.path.join(self.milvus_dir, "db", "tables", collection_name)
             total_vectors, total_ids, total_rows = self.get_files_data(collection_name, collection_path, milvus_meta)
 
         return total_vectors, total_ids, total_rows

--- a/pymilvusdm/core/save_data.py
+++ b/pymilvusdm/core/save_data.py
@@ -9,15 +9,13 @@ class SaveData:
         self.logger = logger
         self.data_dir = data_dir
         self.timestamp = timestamp
-        self.dirs = self.data_dir + '/' + timestamp
-        if not os.path.exists(self.dirs):
-            os.makedirs(self.dirs)
-        if not os.path.exists(self.dirs + '/yamls'):
-            os.makedirs(self.dirs + '/yamls')
-        
+        self.dirs = os.path.join(self.data_dir, timestamp)
 
     def save_hdf5_data(self, collection_name, partition_tag, vectors, ids):
-        hdf5_filename = self.dirs + '/' + collection_name + '_' + str(partition_tag) + '.h5'
+        hdf5_filename = os.path.join(self.dirs, collection_name, f"{partition_tag}.h5")
+        hdf5_foldername = os.path.dirname(hdf5_filename)
+        if not os.path.exists(hdf5_foldername):
+            os.makedirs(hdf5_foldername)
         try:
             f = h5py.File(hdf5_filename, 'w')
             if type(vectors[0]) == type(b'a'):
@@ -51,10 +49,18 @@ class SaveData:
                     'collection_parameter': collection_parameter,
                 }
             }
-            yaml_filename = self.dirs + '/yamls/' + collection_name + '_' + str(partition_tag) + '.yaml'
-            with open(yaml_filename, 'w') as f:
-                f.write(yaml.dump(hdf2_ymal))
-            self.logger.debug('Successfully saved yamls of collection: {}/partition: {} data in {}!'.format(collection_name, partition_tag, yaml_filename))
+            yaml_filename = os.path.join(self.dirs, "yamls", collection_name, f"{partition_tag}.yaml")
+            yaml_foldername = os.path.dirname(yaml_filename)
+            if not os.path.exists(yaml_foldername):
+                os.makedirs(yaml_foldername)
+
+            with open(yaml_filename, "w") as f:
+                f.write(yaml.dump(hdf2_yaml))
+            self.logger.debug(
+                "Successfully saved yamls of collection: {}/partition: {} data in {}!".format(
+                    collection_name, partition_tag, yaml_filename
+                )
+            )
         except Exception as e:
             self.logger.error("Error with {}".format(e))
             sys.exit(1)

--- a/pymilvusdm/core/save_data.py
+++ b/pymilvusdm/core/save_data.py
@@ -1,8 +1,10 @@
+import os
+import sys
+
 import h5py
 import numpy as np
-import uuid
 import yaml
-import os, sys
+
 
 class SaveData:
     def __init__(self, logger, data_dir, timestamp):
@@ -16,37 +18,50 @@ class SaveData:
         hdf5_foldername = os.path.dirname(hdf5_filename)
         if not os.path.exists(hdf5_foldername):
             os.makedirs(hdf5_foldername)
+
         try:
-            f = h5py.File(hdf5_filename, 'w')
-            if type(vectors[0]) == type(b'a'):
+            f = h5py.File(hdf5_filename, "w")
+            if type(vectors[0]) == type(b"a"):
                 v = []
                 for i in vectors:
                     v.append(list(i))
-                data = np.array(v, dtype=np.uint8) #save np.array and dtype=uint8
+                data = np.array(v, dtype=np.uint8)  # save np.array and dtype=uint8
             else:
                 data = np.array(vectors)
 
-            f.create_dataset(name='embeddings', data=data) 
-            f.create_dataset(name='ids', data=ids)
-            self.logger.debug('Successfully saved data of collection: {}/partition: {} data in {}!'.format(collection_name, partition_tag, hdf5_filename))
-            return hdf5_filename        
+            f.create_dataset(name="embeddings", data=data)
+            f.create_dataset(name="ids", data=ids)
+            self.logger.debug(
+                "Successfully saved data of collection: {}/partition: {} data in {}!".format(
+                    collection_name, partition_tag, hdf5_filename
+                )
+            )
+            return hdf5_filename
         except Exception as e:
             self.logger.error("Error with {}".format(e))
             sys.exit(1)
 
-    def save_yaml(self, collection_name, partition_tag, collection_parameter, version, save_hdf5_name):
+    def save_yaml(
+        self,
+        collection_name,
+        partition_tag,
+        collection_parameter,
+        version,
+        save_hdf5_name,
+    ):
         try:
-            hdf2_ymal = {
-                'H2M':{
-                    'milvus_version': version,
-                    'data_path': [save_hdf5_name],
-                    'data_dir': None,
-                    'dest_host': '127.0.0.1',
-                    'dest_port': 19530,
-                    'mode': 'skip',
-                    'dest_collection_name': collection_name,
-                    'dest_partition_name': partition_tag,
-                    'collection_parameter': collection_parameter,
+            # TODO: `dest_host` and `dest_port` can be set by parameter
+            hdf2_yaml = {
+                "H2M": {
+                    "milvus_version": version,
+                    "data_path": [save_hdf5_name],
+                    "data_dir": None,
+                    "dest_host": "127.0.0.1",
+                    "dest_port": 19530,
+                    "mode": "skip",
+                    "dest_collection_name": collection_name,
+                    "dest_partition_name": partition_tag,
+                    "collection_parameter": collection_parameter,
                 }
             }
             yaml_filename = os.path.join(self.dirs, "yamls", collection_name, f"{partition_tag}.yaml")

--- a/pymilvusdm/requirements.txt
+++ b/pymilvusdm/requirements.txt
@@ -1,3 +1,6 @@
 tqdm
 h5py
 pyyaml
+
+pymilvus
+pymysql


### PR DESCRIPTION
## Changes

- handle when partition_tag contains slash
- lint files and change to use os.path.join
- add pymilvus, pymysql to requirements.txt

## Related Issue

#10 

## Other

I think M2H fails when partition is indexed, and it should be fixed asap.

cc. @rky0930