### PR TITLE
fix bug: UnboundLocalError when segment_list and row_list empty

### DIFF
--- a/pymilvusdm/core/read_milvus_data.py
+++ b/pymilvusdm/core/read_milvus_data.py
@@ -65,10 +65,10 @@ class ReadMilvusDB:
         #     total_vectors += vectors
         #     # total_ids += ids.tolist()
         #     total_ids += ids
-        total_rows = 0
+        total_rows, total_vectors, total_ids = 0, [], []
         for segment_id, rows in zip(segment_list, row_list):
             vectors, ids = self.get_segment_data(collection_path, segment_id, dim, rows, types)
-            if total_rows==0:
+            if total_rows == 0:
                 total_vectors = vectors
                 total_ids = ids
             else:


### PR DESCRIPTION
There will occur the error when the segment_list and row_list are empty, then the total_vectors and total_ids are assignment before clarify. This happened for me when I create all of the partition tags for data, and give None for partition tags when I do the milvus to hdf5, cause the default partition tag None has no data, then the error will occur.